### PR TITLE
redirecting to waiting page after registration

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -17,7 +17,7 @@ export default function RegisterPage() {
     setIsLoading(true);
     const redirectTo =
       process.env.NEXT_PUBLIC_REDIRECT_URL ??
-      `${window.location.origin}/profile`;
+      `${window.location.origin}/waiting-approval`;
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default redirect after Google sign-in to direct users to a waiting approval page if no custom redirect URL is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->